### PR TITLE
configure cheerio html parser to allow for camelCase attributes

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,8 @@ module.exports = function(filePath) {
         var dom = cheerio.load(markup, 
           { 
             decodeEntities: false,
-            xmlMode: false
+            xmlMode: false,
+            lowerCaseAttributeNames: false
           }
         );
         injectSvg(dom);


### PR DESCRIPTION
This is a fix to maintain Angular 2 *ngIf and *ngFor camel case attributes during html parser. 
This a cheerio configuration change. 