### PR TITLE
Add settings object for basepath of image src attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,21 +12,31 @@ This gulp plugin will check all img tags with an external svg and replace the ta
 
 ```html
 <div class="icon">
-  <img src="/src/assets/img/icons/exclamation_mark.svg" class="icon--exclamation-mark">
+  <img src="/assets/img/icons/exclamation_mark.svg" class="icon--exclamation-mark">
 </div>
 ```
 
-NOTE: You currently need to use an absolute path (relative to your project) to your svgs.
+#### Note
 
+You either need to use an absolute path relative to your project root
+
+`/src/assets/img/icons/exclamation_mark.svg`
+
+or pass a configuration object to the plugin
+
+`injectSvg({ base: '/src' })`
+
+#### Example
 
 ```javascript
 var gulp = require('gulp');
 var injectSvg = require('gulp-inject-svg');
+var injectSvgOptions = { base: '/src' };
 
 gulp.task('injectSvg', function() {
 
   return gulp.src('/src/**/*.html')
-    .pipe(injectSvg())
+    .pipe(injectSvg(injectSvgOptions))
     .pipe(gulp.dest('public/'));
 
 });

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ var es = require('event-stream');
 var iconv = require('iconv-lite');
 var gutil = require('gulp-util');
 
-module.exports = function(filePath) {
+module.exports = function(settings) {
 
     var go = function(file, callback) {
 
@@ -39,6 +39,7 @@ module.exports = function(filePath) {
         dom('img').each(function(idx, el) {
             el = dom(el)
             var src = el.attr('src');
+            settings && settings.base ? src = settings.base + src : null;
 
             if (testSvg.test(src) && isLocal(src)) {
 
@@ -47,8 +48,7 @@ module.exports = function(filePath) {
                 var svg;
 
                 try {
-
-                  var inlineTag = fs.readFileSync("./" + src).toString();
+                  var inlineTag = fs.readFileSync('./' + src).toString();
                   var className = el.attr('class');
                   var styles = el.attr('style');
 

--- a/index.js
+++ b/index.js
@@ -17,8 +17,8 @@ module.exports = function(filePath) {
             markup = iconv.encode(markup, 'utf-8');
         }
 
-        var dom = cheerio.load(markup, 
-          { 
+        var dom = cheerio.load(markup,
+          {
             decodeEntities: false,
             xmlMode: false,
             lowerCaseAttributeNames: false
@@ -70,10 +70,10 @@ module.exports = function(filePath) {
 
                 } catch (e) {
 
-									throw new gutil.PluginError({
-									  plugin: 'gulp-inject-svg',
-									  message: 'Could not find file SVG file (' + src + ').'
-									});
+                  throw new gutil.PluginError({
+                    plugin: 'gulp-inject-svg',
+                    message: 'Could not find file SVG file (' + src + ').'
+                  });
 
                 }
 


### PR DESCRIPTION
This allows the plugin to receive a settings object. The settings object should have a base property which will be prepended to the svg src path.

If gulp-inject-svg was to be removed or temporarily disabled on a project all svgs would still load embedded within image tags.